### PR TITLE
Capture interrupt to allow console to be reset to echo mode

### DIFF
--- a/getpass_nix.go
+++ b/getpass_nix.go
@@ -4,6 +4,8 @@ package termutil
 
 import (
 	"io"
+	"os"
+	"os/signal"
 	"syscall"
 	"unsafe"
 )
@@ -23,6 +25,10 @@ func GetPass(prompt string, prompt_fd, input_fd uintptr) ([]byte, error) {
 
 		written += n
 	}
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	defer signal.Stop(c)
 
 	// Write a newline after we're done, since it won't be echoed when the
 	// user presses 'Enter'.


### PR DESCRIPTION
I was having trouble where if you interrupted/ctrl+c while it was prompting for password, the terminal would not be reset to echo mode. So I'm capturing interrupt to stop it.

Ideally this would break out of the password prompt - but I couldn't see an obvious way of doing it.
