### PR TITLE
Remove `import "os"`

### DIFF
--- a/isatty.go
+++ b/isatty.go
@@ -2,8 +2,6 @@
 
 package termutil
 
-import "os"
-
 func Isatty(fd uintptr) bool {
     panic("Not implemented")
 }


### PR DESCRIPTION
I got following errors on building with [gox](https://github.com/mitchellh/gox), so removed `import "os"`. 

```
--> openbsd/386 error: exit status 2
Stderr: # github.com/andrew-d/go-termutil
../../andrew-d/go-termutil/isatty.go:5: imported and not used: "os"

--> openbsd/amd64 error: exit status 2
Stderr: # github.com/andrew-d/go-termutil
../../andrew-d/go-termutil/isatty.go:5: imported and not used: "os"

--> netbsd/386 error: exit status 2
Stderr: # github.com/andrew-d/go-termutil
../../andrew-d/go-termutil/isatty.go:5: imported and not used: "os"

--> netbsd/amd64 error: exit status 2
Stderr: # github.com/andrew-d/go-termutil
../../andrew-d/go-termutil/isatty.go:5: imported and not used: "os"

--> netbsd/arm error: exit status 2
Stderr: # github.com/andrew-d/go-termutil
../../andrew-d/go-termutil/isatty.go:5: imported and not used: "os"

--> plan9/386 error: exit status 2
Stderr: # github.com/andrew-d/go-termutil
../../andrew-d/go-termutil/isatty.go:5: imported and not used: "os"
```
